### PR TITLE
Add missing comma

### DIFF
--- a/src/parallax-background.vue
+++ b/src/parallax-background.vue
@@ -155,7 +155,7 @@
       setBgImageProperty() {
         const hasGradients = this.gradients.length > 0;
         const gradientString = hasGradients ? this.gradients.join() + "," : "";
-        this.bgElement.style.backgroundImage = `${gradientString} url('${this.computedBgImgPath}')`;
+        this.bgElement.style.backgroundImage = `${gradientString}, url('${this.computedBgImgPath}')`;
       },
 
       translateBackground() {


### PR DESCRIPTION
There is a missing comma at method `setBgImageProperty` which will cause *invisible* failure to set the `backgroundImage` if gradients are provided.

Note that the last item of the array won't be added with `,` by `Array.join`.